### PR TITLE
Calling libdbus dbus_threads_init_default() before initialising gconf or using the library.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2013-01-28 Samuel Gyger <samuel@gyger.at>
+        * gconf/GConf/ClientBase.cs: Initialise libdbus' 
+        dbus_threads_init_default () to solve Issues with 
+        multithreaded applications. 
+
 2010-05-11  Mike Kestner  <mkestner@novell.com>
 
 	* configure.in.in: work around removal of Mono.GetOptions.dll

--- a/gconf/GConf/ClientBase.cs
+++ b/gconf/GConf/ClientBase.cs
@@ -37,9 +37,15 @@ namespace GConf
 	
 		[DllImport("gconf-2")]
 		static extern bool gconf_init (int argc, IntPtr argv, out IntPtr err);
+		
+		[DllImport("dbus")]
+		static extern Int32 dbus_threads_init_default ();
 
 		internal void Initialize ()
 		{
+			/* Initialize DBus Glib for multithreading -- It can be called as many times as necessary. */
+			dbus_threads_init_default ();
+			
 			if (!gconf_is_initialized ())
 			{
 				IntPtr err;

--- a/gconf/GConf/gconf-sharp.dll.config.in
+++ b/gconf/GConf/gconf-sharp.dll.config.in
@@ -1,3 +1,4 @@
 <configuration>
   <dllmap dll="gconf-2" target="libgconf-2@LIB_PREFIX@.4@LIB_SUFFIX@"/>
+  <dllmap dll="dbus" target="libdbus-1@LIB_PREFIX@.3@LIB_SUFFIX@"/>
 </configuration>


### PR DESCRIPTION
This commit fixes a problem that came with the new libdbus 6.4.2, see also bgo #683830

Tested it by using the generated library in Banshee, without any further crashes or errors.
