### PR TITLE
Minor compatibility fixes for mono-5 and FreeBSD

### DIFF
--- a/configure.in.in
+++ b/configure.in.in
@@ -27,7 +27,7 @@ esac
 
 AM_CONDITIONAL(PLATFORM_WIN32, test x$platform_win32 = xyes)
 
-AC_CHECK_TOOL(CC, gcc, gcc)
+AC_CHECK_TOOL(CC, cc)
 AC_PROG_CC
 AM_PROG_CC_STDC
 AC_PROG_INSTALL

--- a/sample/gconf/Makefile.am
+++ b/sample/gconf/Makefile.am
@@ -22,7 +22,7 @@ sample.exe: $(SCHEMA) $(srcdir)/sample.glade $(FILES) $(ASSEMBLIES)
 	$(CSC) /out:sample.exe $(FILES) $(REFERENCES) $(RESOURCES)
 
 Settings.cs: $(SCHEMA)
-	MONO_PATH=$(top_builddir)/gconf/GConf/gconf-sharp.dll:${MONO_PATH} $(RUNTIME) $(GCONFDIR)/tools/gconfsharp-schemagen.exe Sample $(SCHEMA) > Settings.cs
+	MONO_PATH=$(top_builddir)/gconf/GConf/:${MONO_PATH} $(RUNTIME) $(GCONFDIR)/tools/gconfsharp-schemagen.exe Sample $(SCHEMA) > Settings.cs
 
 CLEANFILES = sample.exe Settings.cs
 


### PR DESCRIPTION
The following patches are required to compile gnome-sharp on FreeBSD and are of generic application.  